### PR TITLE
Show string/word numbers on search results

### DIFF
--- a/weblate/templates/search.html
+++ b/weblate/templates/search.html
@@ -20,9 +20,8 @@
     </form>
     {% if page_obj.object_list %}
         <div class="search-summary">
-          <p>{% trans "Total strings" %}: {{ total_strings }}</p>
-          <p>{% trans "Total words" %}: {{ total_words }}</p>
-        </div>
+          <p>{{ total_strings }} {% trans "strings" %} / {{ total_words }} {% trans "words" %}</p>
+        </div> 
         {% include "snippets/embed-units.html" with units=page_obj.object_list hide_context=True include_search=True force_source=True show_translation=True %}
         {% include "paginator.html" %}
     {% else %}

--- a/weblate/templates/search.html
+++ b/weblate/templates/search.html
@@ -19,6 +19,10 @@
         {% crispy search_form  %}
     </form>
     {% if page_obj.object_list %}
+        <div class="search-summary">
+          <p>{% trans "Total strings" %}: {{ total_strings }}</p>
+          <p>{% trans "Total words" %}: {{ total_words }}</p>
+        </div>
         {% include "snippets/embed-units.html" with units=page_obj.object_list hide_context=True include_search=True force_source=True show_translation=True %}
         {% include "paginator.html" %}
     {% else %}

--- a/weblate/trans/views/search.py
+++ b/weblate/trans/views/search.py
@@ -158,11 +158,12 @@ def search(request: AuthenticatedHttpRequest, path=None):
             search_form.cleaned_data.get("q", ""), project=context.get("project")
         )
 
+        # Count total strings and sum total words from the search results
         aggregation = units.aggregate(
             total_strings=Count('id'),
             total_words=Sum('num_words')
         )
-
+        # Get the total strings and total words from the aggregation
         total_strings = aggregation['total_strings']
         total_words = aggregation['total_words']
 


### PR DESCRIPTION
## Proposed changes
This pull request addresses issue [#11853](https://github.com/WeblateOrg/weblate/issues/11853), which requests the addition of total string and word counts in the search results. This enhancement provides users with an overview of the number of strings and words directly in the search results.

Display total strings and total words in the search summary of search results:
  - Modified the template search.html to include total strings and total words.
  - Updated search.py to aggregate the total strings and words from the search results and pass the values to the template.

## Checklist
- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added documentation to describe my feature.
- [x] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information
Before:
<img width="1783" alt="image" src="https://github.com/user-attachments/assets/449fa3fa-cb08-4f9f-a9d5-b5b39bcf6a2f">

After:
<img width="1783" alt="image" src="https://github.com/user-attachments/assets/b9cda4da-4573-4a2c-b6e7-e67b4dda0245">

Now shows '37 strings / 300 words' in the search summary, as demonstrated in the example.

