### PR TITLE
Modify generate_credits in reports.py

### DIFF
--- a/weblate/trans/views/reports.py
+++ b/weblate/trans/views/reports.py
@@ -81,12 +81,17 @@ def generate_credits(
         base.filter(language__in=languages, **kwargs)
         .authors_list(
             (start_date, end_date),
-            values_list=("language__name",),
+            values_list=("language__name", "author__username"),
         )
         .order_by("language__name", "-change_count")
     ):
         result[language].append(
-            {"email": author[0], "full_name": author[1], "change_count": author[2]}
+            {
+                "email": author[0],
+                "full_name": author[1],
+                "change_count": author[2],
+                "username": author[4],
+            }
         )
 
     return [{language: authors} for language, authors in result.items()]

--- a/weblate/trans/views/reports.py
+++ b/weblate/trans/views/reports.py
@@ -81,7 +81,7 @@ def generate_credits(
         base.filter(language__in=languages, **kwargs)
         .authors_list(
             (start_date, end_date),
-            values_list=("language__name", "author__username"),
+            values_list=( "author__username","language__name"),
         )
         .order_by("language__name", "-change_count")
     ):
@@ -90,7 +90,7 @@ def generate_credits(
                 "email": author[0],
                 "full_name": author[1],
                 "change_count": author[2],
-                "username": author[4],
+                "username": author[3],
             }
         )
 


### PR DESCRIPTION
## Proposed changes
The issue involves modifying the `generate_credits` function to include the `author_username` field for retrieving and displaying the author's username alongside their full name and email in the translator credits.
## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [x] I have described the changes in the commit messages.

## Other information

